### PR TITLE
Update build command to use mode for GitHub Pages deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        run: npm run build:mode github-pages
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:mode": "vite build --mode",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
-  base: '/react-course-coderhouse/',
-})
+  base: mode === "github-pages" ? "/react-course-coderhouse/" : "/",
+}));


### PR DESCRIPTION
This pull request updates the build command to use a specific mode for GitHub Pages deployment. Previously, the build command was set to `npm run build`, but now it has been changed to `npm run build:mode github-pages`. Additionally, the `vite.config.js` file has been modified to conditionally set the base URL depending on the mode. If the mode is "github-pages", the base URL will be set to "/react-course-coderhouse/", otherwise it will be set to "/". These changes ensure that the build command and base URL are correctly configured for GitHub Pages deployment.