### PR TITLE
Fix subtotal display on checkout page

### DIFF
--- a/src/components/Checkout.jsx
+++ b/src/components/Checkout.jsx
@@ -175,7 +175,7 @@ export default function Checkout() {
                 </Fragment>
               );
             })}
-            <h3 className="h3 text-white text-end">Subtotal: ${subtotal}</h3>
+            <h3 className="h3 text-white text-end">Subtotal: ${subtotal.toFixed(2)}</h3>
           </ul>
         </div>
         <div className="container col-12 col-md-6 col-lg-4 p-3">


### PR DESCRIPTION
This pull request fixes an issue where the subtotal on the checkout page was not displayed with two decimal places. The commit "Fixed show subtotal with two decimals on checkout page" addresses this issue by modifying the code to use the `toFixed` method to ensure that the subtotal is displayed with two decimal places.